### PR TITLE
0.1.2

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -26,8 +26,8 @@ module.exports = {
     './rules/import',
     './rules/mocha',
     './rules/prettier',
-  ].map(
-    require.resolve,
-  ),
+  ].map(require.resolve),
   rules: {},
+
+  reportUnusedDisableDirectives: true,
 }

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Xpring's base TS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-base/rules/@typescript-eslint.js
+++ b/packages/eslint-config-base/rules/@typescript-eslint.js
@@ -732,6 +732,19 @@ module.exports = {
       rules: {
         // No need to handle promise exceptions in test blocks, since they'll just be handled anyways.
         '@typescript-eslint/no-floating-promises': 'off',
+
+
+        // We purposefully break some TypeScript assumptions in various tests (like giving `null` to a database access function)
+        '@typescript-eslint/ban-ts-comment': [
+          'error',
+          {
+            // TODO: Turn ts-ignore to true when TS 3.9 gets released
+            'ts-expect-error': false,
+            'ts-ignore': false,
+            'ts-nocheck': true,
+            'ts-check': false,
+          },
+        ],
       },
     },
   ],

--- a/packages/eslint-config-base/rules/@typescript-eslint.js
+++ b/packages/eslint-config-base/rules/@typescript-eslint.js
@@ -157,7 +157,10 @@ module.exports = {
       {
         selector: 'variable',
         types: ['boolean'],
-        format: ['camelCase'],
+        // This isn't really PascalCase, because the prefix gets removed.
+        // So something like "isValidPayID" would get the prefix stripped
+        // and "ValidPayID" is in PascalCase.
+        format: ['PascalCase'],
         prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
       },
       // Enforce that type parameters (generics) are prefixed with T

--- a/packages/eslint-config-base/rules/import.js
+++ b/packages/eslint-config-base/rules/import.js
@@ -227,6 +227,14 @@ module.exports = {
 
   overrides: [
     {
+      files: ['src/index.ts'],
+      rules: {
+        // In SDKs, we export stuff that isn't used by the library itself,
+        // for consumption in other libraries/apps.
+        'import/no-unused-modules': 'off',
+      },
+    },
+    {
       files: ['test/**/*.ts'],
       rules: {
         // Warn when modules have too many dependencies (code smell)


### PR DESCRIPTION
## High Level Overview of Change

Various fixes I came across while working on `xpring-common-js`.

- Disable @ts-* comment error for *.test.ts files, where it's reasonable to pass `null` on purpose.
- Allow src/index.ts to export things that are not used (needed for libraries we build that exports functionality).
- Fix bug in boolean variable naming-convention
- Report on unused ESLint disable directives

### Context of Change

Various quality and polish improvements to the linting configuration.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

