### PR TITLE
0.2.1

### DIFF
--- a/packages/eslint-config-base/CHANGELOG.md
+++ b/packages/eslint-config-base/CHANGELOG.md
@@ -9,6 +9,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.2.1 - May 18, 2020
+
+- Upgrade `eslint-plugin-mocha` to 7.0.0
+
+## 0.2.0 - May 11, 2020
+
+- Bump required version of ESLint to 7.0.0
+- Add new rules and options from ESLint 7.0.0
+  - `default-case-last`
+  - `no-void`
+  - `no-useless-backreference`
+  - `no-restricted-exports`
+
+## 0.1.2 - May 8, 2020
+
+- Disable `@ts-*` comment errors for `*.test.ts` files, where it's reasonable to pass null on purpose
+- Allow src/index.ts to export things that are not used
+  - needed for libraries we build that exports functionality.
+- Report on unused ESLint disable directives
+- Fix bug in boolean variable naming-convention
+
 ## 0.1.1 - May 5, 2020
 
 Literally no changes, just redeployed to NPM.

--- a/packages/eslint-config-base/CHANGELOG.md
+++ b/packages/eslint-config-base/CHANGELOG.md
@@ -11,6 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 0.2.1 - May 18, 2020
 
+- Allow `@types/**/*.d.ts` files to exist without warning.
 - Upgrade `eslint-plugin-mocha` to 7.0.0
 
 ## 0.2.0 - May 11, 2020

--- a/packages/eslint-config-base/package-lock.json
+++ b/packages/eslint-config-base/package-lock.json
@@ -804,24 +804,13 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.3.0.tgz",
-      "integrity": "sha512-Cd2roo8caAyG21oKaaNTj7cqeYRWW1I2B5SfpKRp0Ip1gkfwoR1Ow0IGlPWnNjzywdF4n+kHL8/9vM6zCJUxdg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-7.0.0.tgz",
+      "integrity": "sha512-1qh2wBCCIobzyRfXppo7wrFctYjE1tEdp0rTzLVFVKfQTTh6RZ7HCQXcxj70HQ1BVp3NqEVm7puwHeSonRizrA==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
         "ramda": "^0.27.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        }
       }
     },
     "eslint-plugin-prettier": {

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -31,7 +31,7 @@
     "@typescript-eslint/parser": "^2.31.0",
     "eslint": ">= 7",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-mocha": "^6.3.0",
+    "eslint-plugin-mocha": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-tsdoc": "^0.2.4",
     "prettier": "^2.0.5",
@@ -43,7 +43,7 @@
     "eslint": "^7.0.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-mocha": "^6.3.0",
+    "eslint-plugin-mocha": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-tsdoc": "^0.2.4",
     "prettier": "^2.0.5"

--- a/packages/eslint-config-base/rules/import.js
+++ b/packages/eslint-config-base/rules/import.js
@@ -243,6 +243,13 @@ module.exports = {
       }
     },
     {
+      files: ['@types/**/*.d.ts'],
+      rules: {
+        // Declaration files could allegedly be parsed as a valid script according to eslint-plugin-import.
+        'import/unambiguous': 'off',
+      },
+    },
+    {
       files: ['test/**/*.test.ts'],
       rules: {
         // Our Mocha test files never export anything.
@@ -250,7 +257,6 @@ module.exports = {
 
         // Importing mocha is a side-effecting import
         'import/no-unassigned-import': ['error', { allow: ['mocha'] }],
-
       },
     },
   ],


### PR DESCRIPTION
## High Level Overview of Change

- Upgrade `eslint-plugin-mocha` to 7.0.0
- Ignore `import/unambiguous` errors in `@types/**/*.d.ts` files.

### Context of Change

Needed to allow custom declaration files in TypeScript projects.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Now we won't get a linting violation for a `declare module 'module-name` in a `*.d.ts` file.